### PR TITLE
- Adding a spec file for rpm build of the python module to ease test

### DIFF
--- a/python-redfish.spec
+++ b/python-redfish.spec
@@ -1,0 +1,34 @@
+%global srcname redfish
+
+Name:           python-%{srcname}
+Version:        0.1
+Release:        %mkrel 1
+Summary:        Redfish python library
+
+Group:          Development/Python
+License:        Apache v2.0
+URL:            https://github.com/devananda/python-redfish
+Source0:        %name-%version.tar.gz
+
+BuildArch:      noarch
+BuildRequires:  python-devel
+BuildRequires:  python-setuptools
+
+%description
+The Redfish API supports dialoging with a Redfish compliant 
+system such as defined by http://www.redfishcertification.org
+
+%prep
+%setup -q -n %{name}
+#-%{version}
+
+%build
+%{__python} setup.py build
+
+%install
+%{__python} setup.py install -O1 --skip-build --root %{buildroot}
+
+%files
+%dir %{python_sitelib}/redfish
+%{python_sitelib}/redfish/*
+%{python_sitelib}/python_redfish*

--- a/redfish/connection.py
+++ b/redfish/connection.py
@@ -294,7 +294,7 @@ class RedfishConnection(object):
             request_headers = dict()
         request_headers['Content-Type'] = 'application/json'
         # NOTE:  don't assume any newly created resource is included in the
-        # # response.  Only the Location header matters.
+        # response.  Only the Location header matters.
         # the response body may be the new resource, it may be an
         # ExtendedError, or it may be empty.
         return self._op('POST', suburi, request_headers, request_body)


### PR DESCRIPTION
Suited for Mageia for the moment. Easily adaptable for Fedora e.g. by replacing the %mkrel macro by the fedora one.

It allows to install as a package and not pollute your environment.
